### PR TITLE
non-blocking stdout/stderr streams

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,7 +1,10 @@
 from unittest import TestCase
 from subprocess import CalledProcessError
+from mock import patch
+from io import BytesIO
 
 from wharfrat import interface
+
 
 class TestInterface(TestCase):
     # System test for the external interface
@@ -28,3 +31,13 @@ class TestInterface(TestCase):
 
         self.assertEqual(e.exception.returncode, 1)
         self.assertEqual(e.exception.output, 'FAIL\n')
+
+    @patch('sys.stdout', new_callable=BytesIO)
+    def test_streaming(self, mock_stdout):
+
+        # NOTE: doesn't test the timing; for that we'd need separate threads/processes
+        command = 'echo a; sleep 0; echo b; exit 0'
+        output = interface.issue(command)
+
+        self.assertEqual(output, 'a\nb\n')
+        self.assertEqual(output, mock_stdout.getvalue())

--- a/wharfrat/interface.py
+++ b/wharfrat/interface.py
@@ -1,11 +1,36 @@
-from subprocess import check_output, STDOUT, CalledProcessError
+from subprocess import Popen, STDOUT, PIPE, CalledProcessError
 import sys
+
 
 def issue(command):
     try:
-        response = check_output(command, stderr=STDOUT, shell=True)
+        p = Popen(command,
+                  stdout=PIPE,
+                  stderr=PIPE,
+                  shell=True)
+        response = handle_output(p)
+        e = p.returncode
+        if e:
+            raise CalledProcessError(e, command, output=response)
     except CalledProcessError as e:
         print e.output
         raise e
-    print response
     return response
+
+
+def handle_output(p):
+    response = []
+    try:
+        c = p.communicate()
+        while c:
+            out, err = c
+            if out:
+                response.append(out)
+                sys.stdout.write(out)
+            if err:
+                response.append(err)
+                sys.stderr.write(err)
+            c = p.communicate()
+    except ValueError as e:
+        pass # .communicate() on dead process, it's fine...
+    return ''.join(response)


### PR DESCRIPTION
changes the behavior slightly as we propagate stdout/stderr through (as well as capture).